### PR TITLE
Add CoinAPI for libPiggyEconomy

### DIFF
--- a/src/DaPigGuy/libPiggyEconomy/libPiggyEconomy.php
+++ b/src/DaPigGuy/libPiggyEconomy/libPiggyEconomy.php
@@ -10,6 +10,7 @@ use DaPigGuy\libPiggyEconomy\providers\BedrockEconomyProvider;
 use DaPigGuy\libPiggyEconomy\providers\EconomyProvider;
 use DaPigGuy\libPiggyEconomy\providers\EconomySProvider;
 use DaPigGuy\libPiggyEconomy\providers\XPProvider;
+use DaPigGuy\libPiggyEconomy\providers\CoinAPIProvider;
 
 class libPiggyEconomy
 {
@@ -29,6 +30,7 @@ class libPiggyEconomy
             self::registerProvider(["economys", "economyapi"], EconomySProvider::class);
             self::registerProvider(["bedrockeconomy"], BedrockEconomyProvider::class);
             self::registerProvider(["xp", "exp", "experience"], XPProvider::class);
+            self::registerProvider(["coinapi", "coin"], CoinAPIProvider::class);
         }
     }
 

--- a/src/DaPigGuy/libPiggyEconomy/providers/CoinAPIProvider.php
+++ b/src/DaPigGuy/libPiggyEconomy/providers/CoinAPIProvider.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaPigGuy\libPiggyEconomy\providers;
+
+use onebone\coinapi\CoinAPI;
+use pocketmine\player\Player;
+use pocketmine\Server;
+
+class CoinAPIProvider extends EconomyProvider
+{
+    private CoinAPI $coinAPI;
+
+    public static function checkDependencies(): bool
+    {
+        return Server::getInstance()->getPluginManager()->getPlugin("CoinAPI") !== null;
+    }
+
+    public function __construct()
+    {
+        $this->coinAPI = CoinAPI::getInstance();
+    }
+
+    public function getMonetaryUnit(): string
+    {
+        return $this->coinAPI->getMonetaryUnit();
+    }
+
+    public function getMoney(Player $player, callable $callback): void
+    {
+        $callback($this->coinAPI->myCoin($player) ?: 0);
+    }
+
+    public function giveMoney(Player $player, float $amount, ?callable $callback = null): void
+    {
+        $ret = $this->coinAPI->addCoin($player, $amount);
+        if ($callback) $callback($ret === CoinAPI::RET_SUCCESS);
+    }
+
+    public function takeMoney(Player $player, float $amount, ?callable $callback = null): void
+    {
+        $ret = $this->coinAPI->reduceCoin($player, $amount);
+        if ($callback) $callback($ret === CoinAPI::RET_SUCCESS);
+    }
+
+    public function setMoney(Player $player, float $amount, ?callable $callback = null): void
+    {
+        $ret = $this->coinAPI->setCoin($player, $amount);
+        if ($callback) $callback($ret === CoinAPI::RET_SUCCESS);
+    }
+}


### PR DESCRIPTION
- Add new provider, that is CoinAPI, I see many people are quite disappointed when my plugin uses libPiggyEconomy because it does not support CoinAPI, and most people see CoinAPI as a plugin that helps them make money by recharging the server. 
- Please accept this pull request

Thank Author and Development Team for reading and accept

Written by: ClickedTran
Once again thank you all