### PR TITLE
Add SimpleEconomy provider and register

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
         run: |
           wget -O vendor/BedrockEconomy.phar https://poggit.pmmp.io/r/230746/BedrockEconomy.phar
           wget -O vendor/EconomyAPI.phar https://poggit.pmmp.io/r/153507/EconomyAPI.phar
+          wget -O vendor/SimpleEconomy.phar https://poggit.pmmp.io/r/262879/SimpleEconomy.phar
       - name: Run PHPStan
         uses: paroxity/pmmp-phpstan-action@5.12.0
         with:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,6 +7,7 @@ parameters:
   scanDirectories:
     - phar:///source/vendor/BedrockEconomy.phar/src/
     - phar:///source/vendor/EconomyAPI.phar/src/
+    - phar:///source/vendor/SimpleEconomy.phar/src/
   excludePaths:
     analyse:
      - source/vendor

--- a/src/DaPigGuy/libPiggyEconomy/libPiggyEconomy.php
+++ b/src/DaPigGuy/libPiggyEconomy/libPiggyEconomy.php
@@ -9,6 +9,7 @@ use DaPigGuy\libPiggyEconomy\exceptions\UnknownProviderException;
 use DaPigGuy\libPiggyEconomy\providers\BedrockEconomyProvider;
 use DaPigGuy\libPiggyEconomy\providers\EconomyProvider;
 use DaPigGuy\libPiggyEconomy\providers\EconomySProvider;
+use DaPigGuy\libPiggyEconomy\providers\SimpleEconomyProvider;
 use DaPigGuy\libPiggyEconomy\providers\XPProvider;
 
 class libPiggyEconomy
@@ -28,6 +29,7 @@ class libPiggyEconomy
 
             self::registerProvider(["economys", "economyapi"], EconomySProvider::class);
             self::registerProvider(["bedrockeconomy"], BedrockEconomyProvider::class);
+            self::registerProvider(["simpleeconomy"], SimpleEconomyProvider::class);
             self::registerProvider(["xp", "exp", "experience"], XPProvider::class);
         }
     }

--- a/src/DaPigGuy/libPiggyEconomy/providers/SimpleEconomyProvider.php
+++ b/src/DaPigGuy/libPiggyEconomy/providers/SimpleEconomyProvider.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaPigGuy\libPiggyEconomy\providers;
+
+use NhanAZ\SimpleEconomy\Main as SimpleEconomy;
+use pocketmine\player\Player;
+use pocketmine\Server;
+
+class SimpleEconomyProvider extends EconomyProvider
+{
+    private SimpleEconomy $plugin;
+
+    public static function checkDependencies(): bool
+    {
+        return Server::getInstance()->getPluginManager()->getPlugin("SimpleEconomy") !== null;
+    }
+
+    public function __construct()
+    {
+        $plugin = SimpleEconomy::getInstance();
+        assert($plugin !== null);
+        $this->plugin = $plugin;
+    }
+
+    public function getMonetaryUnit(): string
+    {
+        return $this->plugin->getFormatter()->getSymbol();
+    }
+
+    public function getMoney(Player $player, callable $callback): void
+    {
+        $balance = $this->plugin->getMoney($player->getName());
+        $callback($balance ?? (float) $this->plugin->getDefaultBalance());
+    }
+
+    public function giveMoney(Player $player, float $amount, ?callable $callback = null): void
+    {
+        $success = $this->plugin->addMoney($player->getName(), (int) $amount);
+        if ($callback !== null) {
+            $callback($success);
+        }
+    }
+
+    public function takeMoney(Player $player, float $amount, ?callable $callback = null): void
+    {
+        $success = $this->plugin->reduceMoney($player->getName(), (int) $amount);
+        if ($callback !== null) {
+            $callback($success);
+        }
+    }
+
+    public function setMoney(Player $player, float $amount, ?callable $callback = null): void
+    {
+        $success = $this->plugin->setMoney($player->getName(), (int) $amount);
+        if ($callback !== null) {
+            $callback($success);
+        }
+    }
+}


### PR DESCRIPTION
Add a new SimpleEconomyProvider to integrate NhanAZ\SimpleEconomy with libPiggyEconomy. The provider implements dependency checking, retrieves the currency symbol, and implements get/give/take/set money methods (using SimpleEconomy API and invoking optional callbacks). Also register the provider in libPiggyEconomy under the "simpleeconomy" key so the plugin can be auto-detected and used when available.